### PR TITLE
Adds customized generated PDF filename

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,11 @@ module.exports = function(grunt) {
         options: {concat: true},
         src: "test/fixtures/**/*",
         dest: "tmp/concatenated.pdf"
+      },
+      filename: {
+        src: "test/fixtures/test0.md",
+        dest: "tmp",
+        filename: "custom"
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ grunt.initConfig({
 })
 ```
 
+#### Custom PDF name
+This example, adds a `filename` parameter to generate a custom PDF filename. In this case `dest/custom.pdf` will be generated.
+
+```js
+grunt.initConfig({
+  markdownpdf: {
+    options: {},
+    files: {
+      src: "src/*.md",
+      dest: "dest",
+      filename: "custom"
+    }
+  }
+})
+```
+
 #### Replace characters with preProcessMd
 In this example we use a through stream called [split](https://npmjs.org/package/split) to split the markdown file into lines and replace `foo` with `bar`.
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ grunt.initConfig({
 ```
 
 #### Custom PDF name
-This example, adds a `filename` parameter to generate a custom PDF filename. In this case `dest/custom.pdf` will be generated.
+This example adds a `filename` parameter to generate a custom PDF filename. In this case `dest/custom.pdf` will be generated.
 
 ```js
 grunt.initConfig({

--- a/tasks/markdownpdf.js
+++ b/tasks/markdownpdf.js
@@ -46,7 +46,8 @@ module.exports = function (grunt) {
         } else {
 
           var dests = srcs.map(function (src) {
-            var destPath = path.join(f.dest, path.basename(src).replace(/\.(markdown|md)/g, "") + ".pdf")
+            var filename = f.filename || path.basename(src).replace(/\.(markdown|md)/g, "")
+            var destPath = path.join(f.dest, filename + ".pdf")
             grunt.verbose.writeln("Determined dest path: " + destPath)
             return destPath
           })

--- a/test/markdownpdf_test.js
+++ b/test/markdownpdf_test.js
@@ -40,5 +40,14 @@ exports.markdownpdf = {
     test.ok(contents.length > 0)
 
     test.done()
+  },
+  filename: function(test) {
+    test.expect(1)
+
+    var contents = grunt.file.read('tmp/custom.pdf')
+
+    test.ok(contents.length > 0)
+
+    test.done()
   }
 }


### PR DESCRIPTION
Sometimes it's desirable to have a custom PDF filename that differs from the source markdown file. For instance, it may be desirable to insert the git commit number into the generated PDF filename. This PR makes creating a custom PDF filename possible for this and other purposes.
