### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-markdown-pdf",
   "description": "Grunt plugin to convert Markdown documents to PDF",
-  "version": "3.0.1",
+  "version": "3.0.0",
   "homepage": "https://github.com/alanshaw/grunt-markdown-pdf",
   "author": {
     "name": "Alan Shaw",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-markdown-pdf",
   "description": "Grunt plugin to convert Markdown documents to PDF",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "homepage": "https://github.com/alanshaw/grunt-markdown-pdf",
   "author": {
     "name": "Alan Shaw",
@@ -43,7 +43,7 @@
     "template"
   ],
   "dependencies": {
-    "markdown-pdf": "~7.0.0",
+    "markdown-pdf": "~9.0.0",
     "async": "~0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "template"
   ],
   "dependencies": {
-    "markdown-pdf": "~5.2.0",
+    "markdown-pdf": "~7.0.0",
     "async": "~0.9.0"
   }
 }


### PR DESCRIPTION
Update version of markdown-pdf for compatibility with newer node/macOS Sierra. Noticeable changes
1.  PDFs are smaller as all text in markdown-pdf 7.0.0 is preserved, no longer fully rasters whole page
2.  Runs on macOS Sierra
3.  Uses PhantomJS 2.1.3 instead of 1.9.13, and has it's own prebuilt version
4.  Changes to defaults, and other improvements https://github.com/alanshaw/markdown-pdf/compare/v5.3.0...v7.0.0?w=0
   -  Font size default is now 0.625em instead of 0.75em
   -  Page margins are now 2cm by default, so to match the old default of 1cm
   -  hyperlinks clickable now, https://github.com/alanshaw/markdown-pdf/commit/2a662d2d57a71d512524f08c593acd255e989ddc
